### PR TITLE
Skip non-user authors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -73,6 +73,11 @@ function getPrAuthor(): string | undefined {
         return undefined;
     }
 
+    if (!pullRequest.user.type == 'User') {
+        console.log('author not a "User"')
+        return undefined
+    }
+
     return pullRequest.user.login
 }
 run();


### PR DESCRIPTION
As is, the action fails on Dependabot PRs. Pretty sure this is because the author is not a regular user, so assigning to it fails.

We can check the author type with `pullRequest.user.type`.

Regular _human_ users are of the type `"User"`. The `dependabot[bot]` user is of the type `Bot`.

Rather than check for the presence of `"Bot"`, we just limit ourselves to the type `"User"`.

We'll have to publish a new version of the action (probably at patch update, as this is basically a bug fix) afterwards.